### PR TITLE
Correctly set reverse_map nodes with Augeas

### DIFF
--- a/templates/remap.config.erb
+++ b/templates/remap.config.erb
@@ -15,7 +15,7 @@ set regex_map[.='<%= url -%>']/replacement <%= backend %>
 <% if @rev_map and not @rev_map.empty? -%>
 <%   @rev_map.each do |backend,url| -%>
 set reverse_map[.='<%= backend -%>'] <%= backend %>
-set reverse_map[.='<%= url -%>']/replacement <%= url %>
+set reverse_map[.='<%= backend -%>']/replacement <%= url %>
 <%   end -%>
 <% end -%>
 <% if @redirect and not @redirect.empty? -%>


### PR DESCRIPTION
Do the "replacement" on the beforehand created reverse_map 'backend'
node, not a non-existent 'url' node. This fixes issue #3 (was introduced
in 1206d01). Many thanks to @raphink for debugging.
