### PR TITLE
fix broken augeas command for missing records.config entries

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,15 +53,27 @@ class trafficserver::params {
   # These settings here directly translate into augeas settings.
   $mode_reverse = [
       'set proxy.config.url_remap.remap_required 1',
+      'set proxy.config.url_remap.remap_required/type CONFIG',
+      'set proxy.config.url_remap.remap_required/value_type INT',
       'set proxy.config.reverse_proxy.enabled 1',
+      'set proxy.config.reverse_proxy.enabled/type CONFIG',
+      'set proxy.config.reverse_proxy.enabled/value_type INT',
     ]
   $mode_forward = [
       'set proxy.config.url_remap.remap_required 0',
+      'set proxy.config.url_remap.remap_required/type CONFIG',
+      'set proxy.config.url_remap.remap_required/value_type INT',
       'set proxy.config.reverse_proxy.enabled 0',
+      'set proxy.config.reverse_proxy.enabled/type CONFIG',
+      'set proxy.config.reverse_proxy.enabled/value_type INT',
     ]
   $mode_both = [
       'set proxy.config.url_remap.remap_required 0',
+      'set proxy.config.url_remap.remap_required/type CONFIG',
+      'set proxy.config.url_remap.remap_required/value_type INT',
       'set proxy.config.reverse_proxy.enabled 1',
+      'set proxy.config.reverse_proxy.enabled/type CONFIG',
+      'set proxy.config.reverse_proxy.enabled/value_type INT',
     ]
   # Default mode of operation:
   $mode = 'reverse'


### PR DESCRIPTION
proxy.config.reverse_proxy.enabled has been removed from the standard
records.config. If we want to make sure that the entry is created
correctly, we need to over-specifiy it in cases where it still exists.
