### PR TITLE
Fixed URLs

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -14,12 +14,12 @@
 
 name    'brainsware-trafficserver'
 version '0.2.3'
-source 'https://github.com/Brainsware.org/puppet-trafficserver'
+source 'https://github.com/Brainsware/puppet-trafficserver'
 author 'Brainsware.org'
 license 'Apache 2.0'
 summary 'manage trafficserver installation and configuration'
 description 'manage trafficserver installation and configuration'
-project_page 'https://github.com/Brainsware.org/puppet-trafficserver'
+project_page 'https://github.com/Brainsware/puppet-trafficserver'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 4.1.0'


### PR DESCRIPTION
This fixes the URL used in Puppet Forge and makes usage of this module easier with several deployment scripts.