### PR TITLE
ssl_multicert: fix parsing of lines with missing fields

### DIFF
--- a/lib/puppet/provider/trafficserver_ssl_multicert/parsed.rb
+++ b/lib/puppet/provider/trafficserver_ssl_multicert/parsed.rb
@@ -70,6 +70,12 @@ Puppet::Type.type(:trafficserver_ssl_multicert).provide(
           h[key.to_sym] = value.to_s
         }
         h[:name] = h[:ssl_cert_name]
+
+        # initialize unmentioned fields with the empty string
+        # so that out-of-sync is detected properly (issue #18)
+        ValidKeys.reject { |k| h.has_key?(k) }.each do |key|
+          h[key] = ''
+        end
       end
     end
 end


### PR DESCRIPTION
Uninitialized is-values on properties seem to result in missing hits
during out-of-sync checks [citation needed]. By considering their
value to be the empty string, the agent can make correct syncing
decisions now.

Note that `puppet resource trafficserver_ssl_multicert` still works
as expected and will not include bogus empty string values in the manifest
output.