### PR TITLE
Traffic ctl

### DIFF
--- a/lib/puppet/provider/trafficserver_record/traffic_ctl.rb
+++ b/lib/puppet/provider/trafficserver_record/traffic_ctl.rb
@@ -1,0 +1,50 @@
+#   Copyright 2016 Brainsware
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+Puppet::Type.type(:trafficserver_record).provide(:traffic_ctl) do
+  desc 'Manage traffic server records.config entries using traffic_ctl command'
+
+  commands traffic_ctl: 'traffic_ctl'
+
+  mk_resource_methods
+
+  # this method is only called when value isn't insync?
+  def value=(value)
+    @property_hash[:value] = value
+
+    options = ['config']
+    options << 'set' << @property_hash[:record] << value
+    traffic_ctl(options)
+  end
+
+  # get all records.config entries at the beginning
+  def self.instances
+    records = traffic_ctl('config', 'match', '.')
+    records.split("\n").map do |line|
+      name, value = line.split(%r{:\s+}, 2)
+      # and initialize @property_hash
+      new(name: name,
+          record: name,
+          value: value.to_s)
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov
+      end
+    end
+  end
+end

--- a/manifests/storage/linux.pp
+++ b/manifests/storage/linux.pp
@@ -10,10 +10,11 @@ define trafficserver::storage::linux (
   # the "name" in udev..
   $kernel = regsubst($path, '^/dev/(.+)$', '\1')
 
-  concat::fragment { "ensure ${path} ${ensure} in device file":
-    ensure  => $ensure,
-    target  => $trafficserver::params::device_file,
-    content => template($trafficserver::params::device_template),
-    notify  => Exec['update udev rules'],
+  if $ensure == 'present' {
+    concat::fragment { "ensure ${path} ${ensure} in device file":
+      target  => $trafficserver::params::device_file,
+      content => template($trafficserver::params::device_template),
+      notify  => Exec['update udev rules'],
+    }
   }
 }

--- a/spec/unit/provider/trafficserver_record/traffic_ctl_spec.rb
+++ b/spec/unit/provider/trafficserver_record/traffic_ctl_spec.rb
@@ -1,0 +1,78 @@
+#   Copyright 2016 Brainsware
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+require 'spec_helper'
+
+describe Puppet::Type.type(:trafficserver_record).provider(:traffic_ctl) do
+  let(:record_name) { 'proxy.config.reverse_proxy.enabled' }
+  let(:resource_properties) do
+    {
+      record: record_name,
+      value: '1',
+      provider: described_class.name
+    }
+  end
+  let(:resource) { Puppet::Type.type(:trafficserver_record).new(resource_properties) }
+  let(:provider) { described_class.new(resource) }
+
+  # because of ``provider.class.instances.first``
+  # we move our ``proxy.config.reverse_proxy.enabled 0`` to the top;)
+  let(:prefetch_output) do
+    <<-PREFETCH
+proxy.config.reverse_proxy.enabled: 0
+proxy.config.ssl.enabled: 0
+proxy.config.ssl.SSLv2: 0
+proxy.config.ssl.SSLv3: 0
+proxy.config.ssl.TLSv1: 1
+proxy.config.ssl.TLSv1_1: 1
+proxy.config.ssl.TLSv1_2: 1
+proxy.config.ssl.compression: 0
+PREFETCH
+  end
+
+  before do
+    Puppet::Util.stubs(:which).with('traffic_ctl').returns('/usr/bin/traffic_ctl')
+    provider.class.stubs(:traffic_ctl).with('config', 'match', '.').returns(prefetch_output)
+    provider.class.stubs(:traffic_ctl).with(['config', 'set', record_name, '1'])
+  end
+
+  let(:instance) { provider.class.instances.first }
+
+  describe 'self.instances' do
+    it 'returns an array of record => value pairs' do
+      provider.class.stubs(:traffic_ctl).with(['config', 'match', '.']).returns(prefetch_output)
+    end
+  end
+
+  describe 'self.prefetch' do
+    it 'prefetch' do
+      provider.class.instances
+      provider.class.prefetch({})
+    end
+  end
+
+  describe 'value=' do
+    it 'sets a traffic record' do
+      # unit testing providers is special, and rubocop doesn't understand :(
+      provider.record=(record_name) # rubocop:disable Style/SpaceAroundOperators, Style/RedundantParentheses
+      provider.value=('1') # rubocop:disable Style/SpaceAroundOperators, Style/RedundantParentheses
+    end
+  end
+
+  describe '#record' do
+    it 'set #record to #name' do
+      expect(instance.name).to eq(record_name)
+    end
+  end
+end


### PR DESCRIPTION
## new providerfor trafficserver_record: traffic_ctl

The 7.0.0 series of Trafficserver removes traffic_line in favour of the
much more consistent traffic_ctl.
This pull-request adds support for that utility.