### PR TITLE
notify the service instead of running traffic_line

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ trafficserver_ssl_multicert { 'example.com':
   ssl_cert_name => 'www.example.com.crt',
   ssl_key_name  => 'www.example.com.key',
 }
-trafficserver_ssl_multicert { mail.'example.com':
+trafficserver_ssl_multicert { 'mail.example.com':
   ssl_cert_name => 'mail.example.com.crt',
   ssl_key_name  => 'mail.example.com.key',
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,15 +32,7 @@ class trafficserver::config {
     ensure => file,
     owner  => $trafficserver::user,
     group  => $trafficserver::group,
-    notify => Exec['trafficserver-config-reload'],
-  }
-
-  # And finally, create an exec here to reload
-  exec { 'trafficserver-config-reload':
-    path        => $trafficserver::bindir,
-    command     => 'traffic_line -x',
-    cwd         => '/',
-    refreshonly => true,
+    notify => Class[trafficserver::service],
   }
 
   Class[trafficserver::config::storage] -> Class[trafficserver::config]

--- a/manifests/config/remap.pp
+++ b/manifests/config/remap.pp
@@ -9,7 +9,7 @@ class trafficserver::config::remap {
     owner  => $owner,
     group  => $group,
     order  => 'numeric',
-    notify => Exec['trafficserver-config-reload'],
+    notify => Class[trafficserver::service],
   }
 
   concat::fragment { 'remap_header':

--- a/manifests/config/storage.pp
+++ b/manifests/config/storage.pp
@@ -9,7 +9,7 @@ class trafficserver::config::storage {
   concat { $trafficserver::params::storage_config:
     owner  => $owner,
     group  => $group,
-    notify => Exec['trafficserver-config-reload'],
+    notify => Class[trafficserver::service],
   }
 
   concat::fragment { 'storage_header':


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.

-->

traffic_line has been deprecated, so it would be tricky to emulate the
same behaviour with traffic_ctl, especially since there are versions of
trafficserver that have *both* binaries.

Instead of trying to be clever, we'll simply notify the service class.

(also: fix a small syntax issue in the README!)